### PR TITLE
feat(string): add 10 new string utilities and improve tests

### DIFF
--- a/src/string/collapseWhitespace.ts
+++ b/src/string/collapseWhitespace.ts
@@ -1,0 +1,3 @@
+export function collapseWhitespace(str: string): string {
+  return str.replace(/\s+/g, " ").trim();
+}

--- a/src/string/endsWith.ts
+++ b/src/string/endsWith.ts
@@ -1,0 +1,4 @@
+export function endsWith(str: string, suffix: string): boolean {
+  if (suffix === "") return true;
+  return str.slice(-suffix.length) === suffix;
+}

--- a/src/string/honorific.ts
+++ b/src/string/honorific.ts
@@ -1,0 +1,46 @@
+// src/string/honorific.ts
+const HONORIFIC_SUFFIXES = [
+  "Jr.",
+  "Sr.",
+  "II",
+  "III",
+  "IV",
+  "V",
+  "VI",
+  "VII",
+  "VIII",
+  "IX",
+  "X",
+];
+
+// Sort suffixes by length descending to match longest first
+const HONORIFIC_SUFFIXES_SORTED = [...HONORIFIC_SUFFIXES].sort(
+  (a, b) => b.length - a.length
+);
+
+/**
+ * Removes a recognized honorific suffix from a string if present.
+ */
+export function removeHonorificSuffix(str: string): string {
+  for (const suffix of HONORIFIC_SUFFIXES_SORTED) {
+    if (str.endsWith(" " + suffix)) {
+      return str.slice(0, -suffix.length - 1);
+    }
+    if (str.endsWith(suffix)) {
+      return str.slice(0, -suffix.length);
+    }
+  }
+  return str;
+}
+
+/**
+ * Returns the honorific suffix if present, otherwise null
+ */
+export function getHonorificSuffix(str: string): string | null {
+  for (const suffix of HONORIFIC_SUFFIXES_SORTED) {
+    if (str.endsWith(" " + suffix) || str.endsWith(suffix)) {
+      return suffix;
+    }
+  }
+  return null;
+}

--- a/src/string/includes.ts
+++ b/src/string/includes.ts
@@ -1,0 +1,3 @@
+export function includes(str: string, search: string): boolean {
+  return str.indexOf(search) !== -1;
+}

--- a/src/string/ordinalSuffix.ts
+++ b/src/string/ordinalSuffix.ts
@@ -1,0 +1,20 @@
+export function ordinalSuffix(num: number): string {
+  const abs = Math.abs(num);
+  const j = abs % 10;
+  const k = abs % 100;
+
+  if (k >= 11 && k <= 13) {
+    return `${num}th`;
+  }
+
+  switch (j) {
+    case 1:
+      return `${num}st`;
+    case 2:
+      return `${num}nd`;
+    case 3:
+      return `${num}rd`;
+    default:
+      return `${num}th`;
+  }
+}

--- a/src/string/removePrefix.ts
+++ b/src/string/removePrefix.ts
@@ -1,0 +1,6 @@
+export function removePrefix(str: string, prefix: string): string {
+  if (str.slice(0, prefix.length) === prefix) {
+    return str.slice(prefix.length);
+  }
+  return str;
+}

--- a/src/string/removeSuffix.ts
+++ b/src/string/removeSuffix.ts
@@ -1,0 +1,6 @@
+export function removeSuffix(str: string, suffix: string): string {
+  if (str.slice(-suffix.length) === suffix) {
+    return str.slice(0, -suffix.length);
+  }
+  return str;
+}

--- a/src/string/replaceAll.ts
+++ b/src/string/replaceAll.ts
@@ -1,0 +1,10 @@
+export function replaceAll(
+  str: string,
+  search: string | RegExp,
+  replace: string
+): string {
+  if (typeof search === "string") {
+    return str.split(search).join(replace);
+  }
+  return str.replace(new RegExp(search, "g"), replace);
+}

--- a/src/string/startsWith.ts
+++ b/src/string/startsWith.ts
@@ -1,0 +1,3 @@
+export function startsWith(str: string, prefix: string): boolean {
+  return str.slice(0, prefix.length) === prefix;
+}

--- a/src/string/trimAll.ts
+++ b/src/string/trimAll.ts
@@ -1,0 +1,3 @@
+export function trimAll(str: string): string {
+  return str.replace(/\s+/g, "");
+}

--- a/test/string/collapseWhitespace.test.ts
+++ b/test/string/collapseWhitespace.test.ts
@@ -1,0 +1,19 @@
+import { collapseWhitespace } from "../../src/string/collapseWhitespace";
+
+describe("collapseWhitespace", () => {
+  it("replaces multiple spaces with single space", () => {
+    expect(collapseWhitespace("a    b  c")).toBe("a b c");
+  });
+
+  it("replaces newlines and tabs with single space", () => {
+    expect(collapseWhitespace("a\nb\tc")).toBe("a b c");
+  });
+
+  it("trims leading and trailing spaces", () => {
+    expect(collapseWhitespace("  a b c  ")).toBe("a b c");
+  });
+
+  it("returns empty string if input is empty", () => {
+    expect(collapseWhitespace("")).toBe("");
+  });
+});

--- a/test/string/endsWith.test.ts
+++ b/test/string/endsWith.test.ts
@@ -1,0 +1,15 @@
+import { endsWith } from "../../src/string/endsWith";
+
+describe("endsWith", () => {
+  it("should return true if string ends with suffix", () => {
+    expect(endsWith("hello world", "world")).toBe(true);
+  });
+
+  it("should return false if string does not end with suffix", () => {
+    expect(endsWith("hello world", "hello")).toBe(false);
+  });
+
+  it("should handle empty suffix", () => {
+    expect(endsWith("hello", "")).toBe(true);
+  });
+});

--- a/test/string/honorific.test.ts
+++ b/test/string/honorific.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  removeHonorificSuffix,
+  getHonorificSuffix,
+} from "../../src/string/honorific";
+
+describe("removeHonorificSuffix", () => {
+  it("removes common honorifics with space", () => {
+    expect(removeHonorificSuffix("John Doe Jr.")).toBe("John Doe");
+    expect(removeHonorificSuffix("Jane Smith Sr.")).toBe("Jane Smith");
+    expect(removeHonorificSuffix("Robert Brown III")).toBe("Robert Brown");
+  });
+
+  it("removes honorifics without preceding space", () => {
+    expect(removeHonorificSuffix("AliceII")).toBe("Alice");
+    expect(removeHonorificSuffix("BobV")).toBe("Bob");
+  });
+
+  it("returns string unchanged if no honorific", () => {
+    expect(removeHonorificSuffix("Emily Davis")).toBe("Emily Davis");
+    expect(removeHonorificSuffix("Michael")).toBe("Michael");
+  });
+
+  it("handles empty string", () => {
+    expect(removeHonorificSuffix("")).toBe("");
+  });
+
+  it("handles multiple honorific-like patterns but only removes last", () => {
+    expect(removeHonorificSuffix("John Jr. III")).toBe("John Jr.");
+  });
+});
+
+describe("getHonorificSuffix", () => {
+  it("returns the honorific if present", () => {
+    expect(getHonorificSuffix("John Doe Jr.")).toBe("Jr.");
+    expect(getHonorificSuffix("Jane Smith III")).toBe("III");
+    expect(getHonorificSuffix("AliceII")).toBe("II");
+  });
+
+  it("returns null if no honorific", () => {
+    expect(getHonorificSuffix("Emily Davis")).toBeNull();
+    expect(getHonorificSuffix("Michael")).toBeNull();
+  });
+
+  it("handles multiple honorific-like patterns and returns last", () => {
+    expect(getHonorificSuffix("John Jr. III")).toBe("III");
+  });
+
+  it("handles empty string", () => {
+    expect(getHonorificSuffix("")).toBeNull();
+  });
+});

--- a/test/string/includes.test.ts
+++ b/test/string/includes.test.ts
@@ -1,0 +1,15 @@
+import { includes } from "../../src/string/includes";
+
+describe("includes", () => {
+  it("should return true if string contains search", () => {
+    expect(includes("hello world", "world")).toBe(true);
+  });
+
+  it("should return false if string does not contain search", () => {
+    expect(includes("hello world", "foo")).toBe(false);
+  });
+
+  it("should handle empty search", () => {
+    expect(includes("hello", "")).toBe(true);
+  });
+});

--- a/test/string/ordinalSuffix.test.ts
+++ b/test/string/ordinalSuffix.test.ts
@@ -1,0 +1,35 @@
+import { ordinalSuffix } from "../../src/string/ordinalSuffix";
+
+describe("ordinalSuffix", () => {
+  it("returns correct suffix for 1-3", () => {
+    expect(ordinalSuffix(1)).toBe("1st");
+    expect(ordinalSuffix(2)).toBe("2nd");
+    expect(ordinalSuffix(3)).toBe("3rd");
+  });
+
+  it('returns "th" for 4-10', () => {
+    for (let i = 4; i <= 10; i++) {
+      expect(ordinalSuffix(i)).toBe(`${i}th`);
+    }
+  });
+
+  it("handles teen exceptions correctly", () => {
+    expect(ordinalSuffix(11)).toBe("11th");
+    expect(ordinalSuffix(12)).toBe("12th");
+    expect(ordinalSuffix(13)).toBe("13th");
+  });
+
+  it("handles higher numbers correctly", () => {
+    expect(ordinalSuffix(21)).toBe("21st");
+    expect(ordinalSuffix(22)).toBe("22nd");
+    expect(ordinalSuffix(23)).toBe("23rd");
+    expect(ordinalSuffix(101)).toBe("101st");
+    expect(ordinalSuffix(112)).toBe("112th");
+  });
+
+  it("handles zero and negative numbers", () => {
+    expect(ordinalSuffix(0)).toBe("0th");
+    expect(ordinalSuffix(-1)).toBe("-1st");
+    expect(ordinalSuffix(-12)).toBe("-12th");
+  });
+});

--- a/test/string/removePrefix.test.ts
+++ b/test/string/removePrefix.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { removePrefix } from "../../src/string/removePrefix";
+
+describe("removePrefix", () => {
+  it("removes the prefix if present", () => {
+    expect(removePrefix("helloWorld", "hello")).toBe("World");
+    expect(removePrefix("foobar", "foo")).toBe("bar");
+  });
+
+  it("returns the string unchanged if prefix not present", () => {
+    expect(removePrefix("helloWorld", "world")).toBe("helloWorld");
+    expect(removePrefix("foobar", "bar")).toBe("foobar");
+  });
+
+  it("handles empty prefix", () => {
+    expect(removePrefix("test", "")).toBe("test");
+  });
+
+  it("handles empty string", () => {
+    expect(removePrefix("", "prefix")).toBe("");
+    expect(removePrefix("", "")).toBe("");
+  });
+});

--- a/test/string/removeSuffix.test.ts
+++ b/test/string/removeSuffix.test.ts
@@ -1,0 +1,22 @@
+import { removeSuffix } from "../../src/string/removeSuffix";
+
+describe("removeSuffix", () => {
+  it("removes the suffix if present", () => {
+    expect(removeSuffix("helloWorld", "World")).toBe("hello");
+    expect(removeSuffix("foobar", "bar")).toBe("foo");
+  });
+
+  it("returns the string unchanged if suffix not present", () => {
+    expect(removeSuffix("helloWorld", "hello")).toBe("helloWorld");
+    expect(removeSuffix("foobar", "foo")).toBe("foobar");
+  });
+
+  it("handles empty suffix", () => {
+    expect(removeSuffix("test", "")).toBe("test");
+  });
+
+  it("handles empty string", () => {
+    expect(removeSuffix("", "suffix")).toBe("");
+    expect(removeSuffix("", "")).toBe("");
+  });
+});

--- a/test/string/replaceAll.test.ts
+++ b/test/string/replaceAll.test.ts
@@ -1,0 +1,15 @@
+import { replaceAll } from "../../src/string/replaceAll";
+
+describe("replaceAll", () => {
+  it("should replace all occurrences of a string", () => {
+    expect(replaceAll("foo bar foo", "foo", "baz")).toBe("baz bar baz");
+  });
+
+  it("should replace using regex", () => {
+    expect(replaceAll("foo1 foo2 foo3", /foo\d/g, "bar")).toBe("bar bar bar");
+  });
+
+  it("should return original string if nothing matches", () => {
+    expect(replaceAll("hello", "x", "y")).toBe("hello");
+  });
+});

--- a/test/string/startsWith.test.ts
+++ b/test/string/startsWith.test.ts
@@ -1,0 +1,15 @@
+import { startsWith } from "../../src/string/startsWith";
+
+describe("startsWith", () => {
+  it("should return true if string starts with prefix", () => {
+    expect(startsWith("hello world", "hello")).toBe(true);
+  });
+
+  it("should return false if string does not start with prefix", () => {
+    expect(startsWith("hello world", "world")).toBe(false);
+  });
+
+  it("should handle empty prefix", () => {
+    expect(startsWith("hello", "")).toBe(true);
+  });
+});

--- a/test/string/trimAll.test.ts
+++ b/test/string/trimAll.test.ts
@@ -1,0 +1,16 @@
+import { trimAll } from "../../src/string/trimAll";
+
+describe("trimAll", () => {
+  it("removes all spaces, tabs, and newlines", () => {
+    expect(trimAll(" a b c ")).toBe("abc");
+    expect(trimAll("a\tb\nc")).toBe("abc");
+  });
+
+  it("returns empty string if input is empty", () => {
+    expect(trimAll("")).toBe("");
+  });
+
+  it("returns string unchanged if no whitespace", () => {
+    expect(trimAll("abc")).toBe("abc");
+  });
+});


### PR DESCRIPTION
- Added new string helpers:
  - startsWith: check if a string starts with a given prefix
  - endsWith: check if a string ends with a given suffix
  - includes: case-sensitive substring check
  - removePrefix: remove a prefix if it exists
  - removeSuffix: remove a suffix if it exists
  - replaceAll: replace all occurrences of a substring
  - honorific: handle suffixes like Jr., Sr., II, III
  - trimAll: remove all whitespace, including tabs/newlines
  - collapseWhitespace: normalize multiple spaces/newlines into one
  - ordinalSuffix: convert numbers to ordinal strings (1 → 1st, 2 → 2nd)

- Each utility has dedicated Vitest coverage
- Fully TypeScript-typed and tree-shakable
- Updated documentation and release notes for v1.1.x